### PR TITLE
Add protocol.land published badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # BetterIDEa - A better IDE for Arweave smartcontracts
 
+[![protocol.land](https://arweave.net/eZp8gOeR8Yl_cyH9jJToaCrt2He1PHr0pR4o-mHbEcY)](https://protocol.land/#/repository/c38d3d29-8fd8-4d40-af69-570e6feca20e)
+
 Try it [here](https://ankushKun.github.io/betterIDE/)
 
 <details>


### PR DESCRIPTION
This PR adds Published on protocol.land badge to the README.

![pl-badge](https://github.com/ar-io/ar-io-node/assets/57343520/602301a9-414b-472c-99ca-78326bd60e75)
