### PR TITLE
Feature/new file dialog : Added Enter KeyBinding To dialogBox 

### DIFF
--- a/next_app/src/components/new-file-dialog.tsx
+++ b/next_app/src/components/new-file-dialog.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { toast } from "sonner";
+import { HtmlContext } from "next/dist/server/future/route-modules/app-page/vendored/contexts/entrypoints";
 
 export function NewFileDialog({ manager, project, collapsed, setCollapsed }: { manager: ProjectManager; project: string; collapsed:boolean; setCollapsed: Dispatch<SetStateAction<boolean>> }) {
   const globalState = useGlobalState();
@@ -27,6 +28,12 @@ export function NewFileDialog({ manager, project, collapsed, setCollapsed }: { m
     setPopupOpen(false);
     setCollapsed(true);
   }
+  const handleEnter =( event :React.KeyboardEvent<HTMLInputElement>  ) =>{
+    if(event.key === "Enter"){
+      newFile();  
+    }
+
+  }
 
   return (
     <Dialog open={popupOpen} onOpenChange={(e) => { setPopupOpen(e); setCollapsed(!e)}}>
@@ -40,7 +47,7 @@ export function NewFileDialog({ manager, project, collapsed, setCollapsed }: { m
           <DialogTitle>Create a new file</DialogTitle>
           <DialogDescription>Enter the name of the file you want to create<br/>(supported extensions: lua, luanb, md)</DialogDescription>
         </DialogHeader>
-        <Input type="text" placeholder="File Name" onChange={(e) => setNewFileName(e.target.value)} />
+        <Input type="text" placeholder="File Name" onChange={(e) => setNewFileName(e.target.value)} onKeyDown={handleEnter}/>
         <Button onClick={() => newFile()}>Create File</Button>
       </DialogContent>
     </Dialog>

--- a/next_app/src/components/new-file-dialog.tsx
+++ b/next_app/src/components/new-file-dialog.tsx
@@ -5,7 +5,6 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { toast } from "sonner";
-import { HtmlContext } from "next/dist/server/future/route-modules/app-page/vendored/contexts/entrypoints";
 
 export function NewFileDialog({ manager, project, collapsed, setCollapsed }: { manager: ProjectManager; project: string; collapsed:boolean; setCollapsed: Dispatch<SetStateAction<boolean>> }) {
   const globalState = useGlobalState();


### PR DESCRIPTION
>In the previous version of the IDE, when you clicked "**New File**" after creating a project, a dialog box would pop up asking you to name the file. You had to **manually** click the "Create File" button to complete the file creation process.

>Now, in the updated version of the IDE, the process has been simplified. When the dialog box appears prompting you to name the file, you can simply press the **Enter key** on your keyboard. The file will be created immediately without needing to click the "Create File" button.

![image](https://github.com/betteridea-dev/ide/assets/38605640/9e1270ff-0b47-404b-b0e7-b64f012498bb)

